### PR TITLE
Fix for safety door, feed hold and cycle start bits

### DIFF
--- a/grbl/system.c
+++ b/grbl/system.c
@@ -41,7 +41,7 @@ void system_init()
 uint8_t system_control_get_state()
 {
   uint8_t control_state = 0;
-  uint8_t pin = (CONTROL_PIN & CONTROL_MASK);
+  uint32_t pin = (CONTROL_PIN & CONTROL_MASK);
   #ifdef INVERT_CONTROL_PIN_MASK
     pin ^= INVERT_CONTROL_PIN_MASK;
   #endif


### PR DESCRIPTION
uint8_t overflows the 32 bit status register