### PR TITLE
Fix for issue #49

### DIFF
--- a/grbl/probe.c
+++ b/grbl/probe.c
@@ -22,7 +22,7 @@
 
 
 // Inverts the probe pin state depending on user settings and probing cycle mode.
-uint8_t probe_invert_mask;
+uint32_t probe_invert_mask;
 
 
 // Probe pin initialization routine.


### PR DESCRIPTION
Correct 32bit mask for probe invert.  My setup works with $6=0, but the output below shows the code working as expected when $6=0 and $6=1

$6=0
Probe Physically Open
<Alarm|WPos:0.000,0.000,0.000,0.000|FS:0,0|Pn:ZA>
Probe is not triggered

Probe Physically Closed
<Alarm|WPos:0.000,0.000,0.000,0.000|FS:0,0|Pn:PZA>
Probe is triggered


$6=1
Probe is Physically Open
<Alarm|WPos:0.000,0.000,0.000,0.000|FS:0,0|Pn:PZA>
Probe is triggered

Probe is Physically Closed
<Alarm|WPos:0.000,0.000,0.000,0.000|FS:0,0|Pn:ZA>
Probe is not triggered

